### PR TITLE
Fix badge backpack push by adopting HTTPS.

### DIFF
--- a/navigator-badge/index.html
+++ b/navigator-badge/index.html
@@ -65,7 +65,7 @@ textarea {
 <script src="bugs.js"></script>
 <script src="../main-page.js"></script>
 <script src="quickbadge.js"></script>
-<script src="http://beta.openbadges.org/issuer.js"></script>
+<script src="https://backpack.openbadges.org/issuer.js"></script>
 <script>
 $(window).ready(function() {
   $("#paster-field, #linker-field, #massive-paster-field").val('');


### PR DESCRIPTION
Update to use HTTPS for backpack issuer script.

Changes to Mozilla Backpack hosting require issuers to call the script with https so it passes browser security rules.
