### PR TITLE
Badge image uses https, add alt text

### DIFF
--- a/navigator-badge/index.html
+++ b/navigator-badge/index.html
@@ -157,7 +157,7 @@ Boom shackalack funky fresh, crackalackin.  Lorem ipsum lol sit amizzle, consect
 </div>
 
 <div id="win" style="display: none">
-  <img src="http://toolness.github.com/hackasaurus-parable/navigator-badge/navigator-badge.png" id="badge">
+  <img src="https://toolness.github.io/hackasaurus-parable/navigator-badge/navigator-badge.png" id="badge" alt="Navigator badge">
   <p>Congratulations! <span class="instructions">If you'd like to send this badge to your backpack, just fill out the form below.</span></p>
   <form>
     <input type="email" id="email" placeholder="E-mail Address">


### PR DESCRIPTION
Attempting to attain the Navigator badge via http://toolness.github.io/hackasaurus-parable/navigator-badge/# is impacted by the badge image being insecure and linking to the .com domain instead of the .io. Additionally, accessibility is limited by the lack of an alt tag on the image.